### PR TITLE
`dango.sh` is now `dango-legacy.sh`

### DIFF
--- a/apps/dango.json
+++ b/apps/dango.json
@@ -16,7 +16,7 @@
     "dependencies": ["gnugo"],
     "actions": {
         "install": [
-            "sudo mv ./dango.sh /usr/local/bin/dango",
+            "sudo mv ./dango-legacy/dango-legacy.sh /usr/local/bin/dango",
             "chmod +x /usr/local/bin/dango"
         ],
         "remove": [


### PR DESCRIPTION
Name change in repo due to python rewrite of dango, to avoid confusion. When `dango.py` is stable, it will supersede `dango.sh`